### PR TITLE
Add configuration option to toggle stderr redirection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 tags
 departure_error.log
 .ruby-version
+.idea/

--- a/lib/departure/command.rb
+++ b/lib/departure/command.rb
@@ -8,10 +8,11 @@ module Departure
     # @param command_line [String]
     # @param error_log_path [String]
     # @param logger [#write_no_newline]
-    def initialize(command_line, error_log_path, logger)
+    def initialize(command_line, error_log_path, logger, redirect_stderr)
       @command_line = command_line
       @error_log_path = error_log_path
       @logger = logger
+      @redirect_stderr = redirect_stderr
     end
 
     # Executes the command returning its status. It also prints its stdout to
@@ -35,7 +36,7 @@ module Departure
 
     private
 
-    attr_reader :command_line, :error_log_path, :logger, :status
+    attr_reader :command_line, :error_log_path, :logger, :status, :redirect_stderr
 
     # Runs the command in a separate process, capturing its stdout and
     # execution status
@@ -60,7 +61,11 @@ module Departure
     #
     # @return [String]
     def full_command
-      "#{command_line} 2> #{error_log_path}"
+      if redirect_stderr
+        "#{command_line} 2> #{error_log_path}"
+      else
+        command_line
+      end
     end
 
     # Validates the status of the execution

--- a/lib/departure/configuration.rb
+++ b/lib/departure/configuration.rb
@@ -1,12 +1,13 @@
 module Departure
   class Configuration
-    attr_accessor :tmp_path, :global_percona_args, :enabled_by_default
+    attr_accessor :tmp_path, :global_percona_args, :enabled_by_default, :redirect_stderr
 
     def initialize
       @tmp_path = '.'.freeze
       @error_log_filename = 'departure_error.log'.freeze
       @global_percona_args = nil
       @enabled_by_default = true
+      @redirect_stderr = true
     end
 
     def error_log_path

--- a/lib/departure/runner.rb
+++ b/lib/departure/runner.rb
@@ -15,6 +15,7 @@ module Departure
       @cli_generator = cli_generator
       @mysql_adapter = mysql_adapter
       @error_log_path = config.error_log_path
+      @redirect_stderr = config.redirect_stderr
     end
 
     # Executes the passed sql statement using pt-online-schema-change for ALTER
@@ -44,12 +45,12 @@ module Departure
     # @param command_line [String]
     # @return [Boolean]
     def execute(command_line)
-      Command.new(command_line, error_log_path, logger).run
+      Command.new(command_line, error_log_path, logger, redirect_stderr).run
     end
 
     private
 
-    attr_reader :logger, :cli_generator, :mysql_adapter, :error_log_path
+    attr_reader :logger, :cli_generator, :mysql_adapter, :error_log_path, :redirect_stderr
 
     # Checks whether the sql statement is an ALTER TABLE
     #

--- a/spec/departure/command_spec.rb
+++ b/spec/departure/command_spec.rb
@@ -9,8 +9,9 @@ describe Departure::Command do
         Departure::Logger, write: true, say: true, write_no_newline: true
       )
     end
+    let(:redirect_stderr) { true }
 
-    let(:runner) { described_class.new(command, error_log_path, logger) }
+    let(:runner) { described_class.new(command, error_log_path, logger, redirect_stderr) }
 
     let(:temp_file) do
       file = Tempfile.new('faked_stdout')
@@ -60,6 +61,16 @@ describe Departure::Command do
       runner.run
 
       expect(logger).to have_received(:write_no_newline).with('hello world\\ntodo roto')
+    end
+
+    context 'when not redirecting stderr' do
+      let(:expected_command) { command }
+      let(:redirect_stderr) { false }
+
+      it 'executes the expected command' do
+        runner.run
+        expect(Open3).to have_received(:popen3).with(expected_command)
+      end
     end
 
     context 'on failure' do

--- a/spec/departure/runner_spec.rb
+++ b/spec/departure/runner_spec.rb
@@ -11,7 +11,8 @@ describe Departure::Runner do
   let(:config) do
     instance_double(
       Departure::Configuration,
-      error_log_path: 'departure_error.log'
+      error_log_path: 'departure_error.log',
+      redirect_stderr: true,
     )
   end
 
@@ -39,7 +40,7 @@ describe Departure::Runner do
 
     before do
       allow(Departure::Command)
-        .to receive(:new).with(command_line, config.error_log_path, logger)
+        .to receive(:new).with(command_line, config.error_log_path, logger, config.redirect_stderr)
         .and_return(cmd)
     end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -170,7 +170,7 @@ describe Departure, integration: true do
       it 'runs pt-online-schema-change with the specified arguments' do
         expect(Departure::Command)
           .to receive(:new)
-          .with(/--chunk-time=1/, anything, anything)
+          .with(/--chunk-time=1/, anything, anything, anything)
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--chunk-time=1' do
@@ -183,7 +183,7 @@ describe Departure, integration: true do
       it 'runs pt-online-schema-change with the specified arguments' do
         expect(Departure::Command)
           .to receive(:new)
-          .with(/--chunk-time=1 --max-lag=2/, anything, anything)
+          .with(/--chunk-time=1 --max-lag=2/, anything, anything, anything)
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--chunk-time=1 --max-lag=2' do
@@ -196,7 +196,7 @@ describe Departure, integration: true do
       it 'runs pt-online-schema-change with the user specified value' do
         expect(Departure::Command)
           .to receive(:new)
-          .with(/--alter-foreign-keys-method=drop_swap/, anything, anything)
+          .with(/--alter-foreign-keys-method=drop_swap/, anything, anything, anything)
           .and_return(command)
 
         ClimateControl.modify PERCONA_ARGS: '--alter-foreign-keys-method=drop_swap' do


### PR DESCRIPTION
We run `db:migrate` inside a Kubernetes job so for logging purposes it would be nice for everything that currently goes to `departure_error.log` (including debug logs if envvar `PTDEBUG=1`) to instead just go to STDERR.

PR to upstream: https://github.com/departurerb/departure/pull/63